### PR TITLE
Modifcations to Ranking Search Fields

### DIFF
--- a/frontend/static/projectDetails.html
+++ b/frontend/static/projectDetails.html
@@ -700,7 +700,7 @@
                     <div style="margin-top: 20px;width: 100%;display: flex">
                     <div title="Enabled for Number Type Fields">
                         <paper-checkbox on-change="displayField" id="enableScoringCoefficientEdit"
-                                        checked="{{fieldForm.enable_scoring_coefficient}}" disabled="{{editType}}" style="margin-top:30px;margin-right: 20px">Use in Document Search</paper-checkbox></div>
+                                        checked="{{fieldForm.enable_scoring_coefficient}}" disabled="{{editType}}" style="margin-top:30px;margin-right: 20px">Use in Document Scoring</paper-checkbox></div>
                         <paper-input style=" float:right; width:50%" class="projectInputStyle" label="Scoring Coefficient:"  value="{{fieldForm.scoring_coefficient}}" id="rankingm" auto-validate pattern="([0-9]*[.])?[0-9]+" error-message="Numbers or Floats only!"></paper-input>
                     <paper-tooltip fit-to-visible-bounds="true" position="left" for="rankingm">Affects search ranking by multiplying the elastic search score by value of this field times the value of the scoring coefficient.</paper-tooltip>
                     </div>

--- a/frontend/static/projectDetails.html
+++ b/frontend/static/projectDetails.html
@@ -563,7 +563,7 @@
 
                     <paper-dropdown-menu id="typeFieldEdit" style="margin:0px;" class="projectInputStyle"
                                          label="Type*:">
-                        <paper-listbox id="editTypeValue" selected="{{_getType(fieldForm.type)}}" slot="dropdown-content">
+                        <paper-listbox id="editTypeValue" on-selected-item-changed="checkEditType" selected="{{_getType(fieldForm.type)}}" slot="dropdown-content">
                             <template is="dom-repeat" items="{{type}}" as="item">
                                 <paper-item value={{item}}>{{item}}</paper-item>
                             </template>
@@ -698,12 +698,10 @@
                     </div>
 
                     <div style="margin-top: 20px;width: 100%;display: flex">
-                    
+                    <div title="Enabled for Number Type Fields">
                         <paper-checkbox on-change="displayField" id="enableScoringCoefficientEdit"
-                                        checked="{{fieldForm.enable_scoring_coefficient}}" style="margin-top:30px;margin-right: 20px">Ranked
-                            Search</paper-checkbox>
-                        <paper-tooltip for="enable_scoring_coefficient">Enable ranked Search</paper-tooltip>
-                        <paper-input style="float:right;width:50%;visibility: {{fieldForm.visibility}}" class="projectInputStyle" label="Scoring Coefficient:"  value="{{fieldForm.scoring_coefficient}}" id="rankingm" auto-validate pattern="([0-9]*[.])?[0-9]+" error-message="Numbers or Floats only!"></paper-input>
+                                        checked="{{fieldForm.enable_scoring_coefficient}}" disabled="{{editType}}" style="margin-top:30px;margin-right: 20px">Use in Document Search</paper-checkbox></div>
+                        <paper-input style=" float:right; width:50%" class="projectInputStyle" label="Scoring Coefficient:"  value="{{fieldForm.scoring_coefficient}}" id="rankingm" auto-validate pattern="([0-9]*[.])?[0-9]+" error-message="Numbers or Floats only!"></paper-input>
                     <paper-tooltip fit-to-visible-bounds="true" position="left" for="rankingm">Affects search ranking by multiplying the elastic search score by value of this field times the value of the scoring coefficient.</paper-tooltip>
                     </div>
                    
@@ -790,7 +788,7 @@
 
 
                     <paper-dropdown-menu id="typeDropDown" style="margin:0px;" class="projectInputStyle" label="Type*:">
-                        <paper-listbox id="fieldtypeinput" slot="dropdown-content" selected="0">
+                        <paper-listbox id="fieldtypeinput"  on-selected-item-changed="checkAddType" slot="dropdown-content" selected="0">
                             <template is="dom-repeat" items="{{type}}" as="item">
                                 <paper-item value={{item}}>{{item}}</paper-item>
                             </template>
@@ -890,15 +888,15 @@
 
                     </div>
 
-                    <div style="margin-top: 20px;width: 100%;display: flex">
-                    
+                    <div style="margin-top: 20px;width: 100%;display: flex" >
+                    <div title="Enabled for Number Type Fields">
                         <paper-checkbox on-change="displayAddField" id="enable_scoring_coefficient"
-                                         style="margin-top:30px;margin-right: 20px">Ranked
-                            Search</paper-checkbox>
-                        <paper-tooltip for="enable_scoring_coefficient">Enable ranked Search</paper-tooltip>
+                                         style="margin-top:30px;margin-right: 20px;" disabled="{{addType}}" >Use in Document Scoring</paper-checkbox>
+                                         </div>
+
 
                          <paper-input style="float:right;width:50%;visibility: hidden" class="projectInputStyle" label="Scoring Coefficient:"  id="fieldRankingMultiplierInput" value="1" auto-validate pattern="([0-9]*[.])?[0-9]+" error-message="Numbers or Floats only!" ></paper-input>
-                    <paper-tooltip fit-to-visible-bounds="true" position="left" for="fieldRankingMultiplierInput">Affects search ranking by multiplying the elastic search score by value of this field times the value of the scoring coefficient.</paper-tooltip>
+                    <paper-tooltip fit-to-visible-bounds="true" for="fieldRankingMultiplierInput">Affects search ranking by multiplying the elastic search score by value of this field times the value of the scoring coefficient.</paper-tooltip>
                         
                     </div>
 

--- a/frontend/static/projectDetails.js
+++ b/frontend/static/projectDetails.js
@@ -572,37 +572,73 @@ poly = Polymer({
         if (this.fieldForm.screen_label == "") this.fieldForm.screen_label = this.fieldForm.name;
         if (this.fieldForm.screen_label_plural == "") this.fieldForm.screen_label_plural = this.fieldForm.screen_label;
         if (!this.fieldForm.group_name) this.fieldForm.group_name = "";
-        this.$.updateSavedFields.body = JSON.stringify({
-            "field_name": this.fieldForm.name,
-            "field_object": {
-                "color": this.colorSet[this.editFieldColor],
-                "case_sensitive": this.fieldFormGlossaries.length > 0 ? this.fieldForm.case_sensitive : false,
-                "combine_fields": this.fieldForm.combine_fields,
-                "description": this.fieldForm.description,
-                "glossaries": this.fieldFormGlossaries,
-                "blacklists": this.fieldFormBlacklists,
-                "group_name": this.fieldForm.group_name,
-                "icon": this.$$('#iconField').icon,
-                "name": this.fieldForm.name,
-                "screen_label": this.fieldForm.screen_label,
-                "screen_label_plural": this.fieldForm.screen_label_plural,
-                "search_importance": parseInt(this.$$('#editSearchImpValue').selectedItem.value),
-                "show_as_link": this.$$('#editlinkValue').selectedItem.value,
-                "show_in_facets": this.fieldForm.show_in_facets,
-                "show_in_result": this.$$('#editResultValue').selectedItem.value,
-                /*"rule_extraction_target": this.$$('#editRuleExtractionTargetValue').selectedItem.value,*/
-                "show_in_search": this.fieldForm.show_in_search,
-                "rule_extractor_enabled": this.fieldForm.rule_extractor_enabled,
-                "type": this.$$('#editTypeValue').selectedItem.value,
-                "use_in_network_search": this.fieldForm.use_in_network_search,
-                "predefined_extractor": predefinedExtr,
-                "group_order": parseInt(this.fieldForm.group_order),
-                "field_order": parseInt(this.fieldForm.field_order),
-                "free_text_search": this.fieldForm.free_text_search,
-                "scoring_coefficient": parseFloat(this.fieldForm.scoring_coefficient),
-                "enable_scoring_coefficient": this.fieldForm.enable_scoring_coefficient
-            }
-        });
+        if (this.fieldForm.enable_scoring_coefficient){
+            this.$.updateSavedFields.body = JSON.stringify({
+                "field_name": this.fieldForm.name,
+                "field_object": {
+                    "color": this.colorSet[this.editFieldColor],
+                    "case_sensitive": this.fieldFormGlossaries.length > 0 ? this.fieldForm.case_sensitive : false,
+                    "combine_fields": this.fieldForm.combine_fields,
+                    "description": this.fieldForm.description,
+                    "glossaries": this.fieldFormGlossaries,
+                    "blacklists": this.fieldFormBlacklists,
+                    "group_name": this.fieldForm.group_name,
+                    "icon": this.$$('#iconField').icon,
+                    "name": this.fieldForm.name,
+                    "screen_label": this.fieldForm.screen_label,
+                    "screen_label_plural": this.fieldForm.screen_label_plural,
+                    "search_importance": parseInt(this.$$('#editSearchImpValue').selectedItem.value),
+                    "show_as_link": this.$$('#editlinkValue').selectedItem.value,
+                    "show_in_facets": this.fieldForm.show_in_facets,
+                    "show_in_result": this.$$('#editResultValue').selectedItem.value,
+                    /*"rule_extraction_target": this.$$('#editRuleExtractionTargetValue').selectedItem.value,*/
+                    "show_in_search": this.fieldForm.show_in_search,
+                    "rule_extractor_enabled": this.fieldForm.rule_extractor_enabled,
+                    "type": this.$$('#editTypeValue').selectedItem.value,
+                    "use_in_network_search": this.fieldForm.use_in_network_search,
+                    "predefined_extractor": predefinedExtr,
+                    "group_order": parseInt(this.fieldForm.group_order),
+                    "field_order": parseInt(this.fieldForm.field_order),
+                    "free_text_search": this.fieldForm.free_text_search,
+                    "scoring_coefficient": parseFloat(this.fieldForm.scoring_coefficient),
+                    "enable_scoring_coefficient": this.fieldForm.enable_scoring_coefficient
+                }
+            });
+        }
+        else
+        {
+            this.$.updateSavedFields.body = JSON.stringify({
+                "field_name": this.fieldForm.name,
+                "field_object": {
+                    "color": this.colorSet[this.editFieldColor],
+                    "case_sensitive": this.fieldFormGlossaries.length > 0 ? this.fieldForm.case_sensitive : false,
+                    "combine_fields": this.fieldForm.combine_fields,
+                    "description": this.fieldForm.description,
+                    "glossaries": this.fieldFormGlossaries,
+                    "blacklists": this.fieldFormBlacklists,
+                    "group_name": this.fieldForm.group_name,
+                    "icon": this.$$('#iconField').icon,
+                    "name": this.fieldForm.name,
+                    "screen_label": this.fieldForm.screen_label,
+                    "screen_label_plural": this.fieldForm.screen_label_plural,
+                    "search_importance": parseInt(this.$$('#editSearchImpValue').selectedItem.value),
+                    "show_as_link": this.$$('#editlinkValue').selectedItem.value,
+                    "show_in_facets": this.fieldForm.show_in_facets,
+                    "show_in_result": this.$$('#editResultValue').selectedItem.value,
+                    /*"rule_extraction_target": this.$$('#editRuleExtractionTargetValue').selectedItem.value,*/
+                    "show_in_search": this.fieldForm.show_in_search,
+                    "rule_extractor_enabled": this.fieldForm.rule_extractor_enabled,
+                    "type": this.$$('#editTypeValue').selectedItem.value,
+                    "use_in_network_search": this.fieldForm.use_in_network_search,
+                    "predefined_extractor": predefinedExtr,
+                    "group_order": parseInt(this.fieldForm.group_order),
+                    "field_order": parseInt(this.fieldForm.field_order),
+                    "free_text_search": this.fieldForm.free_text_search,
+                    "enable_scoring_coefficient": this.fieldForm.enable_scoring_coefficient
+                }
+            });
+        }
+
         this.$.updateSavedFields.generateRequest();
         this.$$('#editFieldsDialog').toggle();
 
@@ -834,7 +870,7 @@ poly = Polymer({
 
         this.$.updateSpacyRules.body = (this.$$('#spacyRulesTextArea').value);
         this.$.updateSpacyRules.generateRequest();
-        spacyRulesDialog.toggle();
+        this.$$('#spacyRulesDialog').toggle();
     },
     showSpacyRuleDummy: function () {
         this.$$('#spacyRulesTextArea').value = '{"rules": [],"test_text": "string"}';
@@ -936,6 +972,7 @@ poly = Polymer({
         this.$$('#fieldOrderInput').value="";
         this.$$("#free_text_search").checked = false;
         this.$$('#fieldRankingMultiplierInput').value="1.0";
+        this.$$('#enable_scoring_coefficient').checked =false;
 
         /*this.$$("#fieldRuleExtractorTarget").selected = "2";*/
     },
@@ -1089,36 +1126,72 @@ poly = Polymer({
         }
     }.bind(this);
 
-    var data = JSON.stringify({
-        "field_name": name,
-        "field_object": {
-            "color": color,
-            "case_sensitive": caseSense,
-            "combine_fields": combinefields,
-            "description": description,
-            "glossaries": glossariesNewField,
-            "group_name": groupname,
-            "icon": icon,
-            "name": name,
-            "screen_label": screenlabel,
-            "screen_label_plural": screen_label_plural,
-            "search_importance": searchimp,
-            "show_as_link": link,
-            "show_in_facets": facet,
-            "show_in_result": result,
-            "show_in_search": search,
-            "type": type,
-            "use_in_network_search": networksearch,
-            "rule_extractor_enabled": ruleExtractor,
-            "predefined_extractor": predefinedExtractor,
-            "group_order": groupOrder,
-            "field_order": fieldOrder,
-            "free_text_search": free_text_search,
-            "scoring_coefficient": rankingMultiplier,
-            "enable_scoring_coefficient": esc
-            /*"rule_extraction_target": ruleextractTarget*/
-        }
-    });
+    if(esc){
+        var data = JSON.stringify({
+            "field_name": name,
+            "field_object": {
+                "color": color,
+                "case_sensitive": caseSense,
+                "combine_fields": combinefields,
+                "description": description,
+                "glossaries": glossariesNewField,
+                "group_name": groupname,
+                "icon": icon,
+                "name": name,
+                "screen_label": screenlabel,
+                "screen_label_plural": screen_label_plural,
+                "search_importance": searchimp,
+                "show_as_link": link,
+                "show_in_facets": facet,
+                "show_in_result": result,
+                "show_in_search": search,
+                "type": type,
+                "use_in_network_search": networksearch,
+                "rule_extractor_enabled": ruleExtractor,
+                "predefined_extractor": predefinedExtractor,
+                "group_order": groupOrder,
+                "field_order": fieldOrder,
+                "free_text_search": free_text_search,
+                "scoring_coefficient": rankingMultiplier,
+                "enable_scoring_coefficient": esc
+                /*"rule_extraction_target": ruleextractTarget*/
+            }
+        });
+    }
+    else
+    {
+      
+        var data = JSON.stringify({
+            "field_name": name,
+            "field_object": {
+                "color": color,
+                "case_sensitive": caseSense,
+                "combine_fields": combinefields,
+                "description": description,
+                "glossaries": glossariesNewField,
+                "group_name": groupname,
+                "icon": icon,
+                "name": name,
+                "screen_label": screenlabel,
+                "screen_label_plural": screen_label_plural,
+                "search_importance": searchimp,
+                "show_as_link": link,
+                "show_in_facets": facet,
+                "show_in_result": result,
+                "show_in_search": search,
+                "type": type,
+                "use_in_network_search": networksearch,
+                "rule_extractor_enabled": ruleExtractor,
+                "predefined_extractor": predefinedExtractor,
+                "group_order": groupOrder,
+                "field_order": fieldOrder,
+                "free_text_search": free_text_search,
+                "scoring_coefficient": rankingMultiplier,
+                "enable_scoring_coefficient": esc
+                /*"rule_extraction_target": ruleextractTarget*/
+            }
+        });
+    }
 
     xhr.send(data);
 

--- a/frontend/static/projectDetails.js
+++ b/frontend/static/projectDetails.js
@@ -43,7 +43,8 @@ poly = Polymer({
         this.confirmValue =0
         this.pipelineCall=0
         this.disableColor = "#666666"
-
+        this.addType =false
+        this.editType=true
         this.scope.getIconNames = function(iconset) {
         return iconset.getIconNames();
         ////console("heree");
@@ -572,7 +573,7 @@ poly = Polymer({
         if (this.fieldForm.screen_label == "") this.fieldForm.screen_label = this.fieldForm.name;
         if (this.fieldForm.screen_label_plural == "") this.fieldForm.screen_label_plural = this.fieldForm.screen_label;
         if (!this.fieldForm.group_name) this.fieldForm.group_name = "";
-        if (this.fieldForm.enable_scoring_coefficient){
+        if (!this.editType && this.fieldForm.enable_scoring_coefficient){
             this.$.updateSavedFields.body = JSON.stringify({
                 "field_name": this.fieldForm.name,
                 "field_object": {
@@ -634,7 +635,6 @@ poly = Polymer({
                     "group_order": parseInt(this.fieldForm.group_order),
                     "field_order": parseInt(this.fieldForm.field_order),
                     "free_text_search": this.fieldForm.free_text_search,
-                    "enable_scoring_coefficient": this.fieldForm.enable_scoring_coefficient
                 }
             });
         }
@@ -926,19 +926,21 @@ poly = Polymer({
 
             //console.log(this.fieldForm.scoring_coefficient)
 
-            if(this.fieldForm.scoring_coefficient == undefined || this.fieldForm.scoring_coefficient == ""){
-                this.fieldForm.scoring_coefficient =1
-                this.$$('#rankingm').value = "1.0"
-                /*console.log("hereee");*/
+            if(this.fieldForm.enable_scoring_coefficient==undefined || this.fieldForm.scoring_coefficient == undefined || this.fieldForm.scoring_coefficient == ""){
+                this.fieldForm.scoring_coefficient =1;
+                this.$$('#rankingm').value = "1.0";
+                this.$$('#rankingm').style.visibility = 'hidden';
+                this.editType = true;
+                //console.log("hereee");
             }
 
             if(this.fieldForm.enable_scoring_coefficient)
             {
-                this.fieldForm.visibility = "visible";
+                this.$$('#rankingm').style.visibility = 'visible';
             }
             else
             {
-                this.fieldForm.visibility = "hidden"
+                this.$$('#rankingm').style.visibility = 'hidden';
             }
         }
     },
@@ -973,6 +975,8 @@ poly = Polymer({
         this.$$("#free_text_search").checked = false;
         this.$$('#fieldRankingMultiplierInput').value="1.0";
         this.$$('#enable_scoring_coefficient').checked =false;
+        this.$$('#fieldRankingMultiplierInput').style.visibility ='hidden';
+        this.addType =true
 
         /*this.$$("#fieldRuleExtractorTarget").selected = "2";*/
     },
@@ -1040,6 +1044,39 @@ poly = Polymer({
                 }
             }
         }
+    },
+    checkAddType: function(){
+        if(this.$$('#fieldtypeinput').selectedItem!=undefined || this.$$('#fieldtypeinput').selectedItem !=null)
+        {var type = this.$$('#fieldtypeinput').selectedItem.value;
+        /*console.log(type)*/
+        if(type=='number')
+        {
+            this.addType = false
+           /* console.log(true)*/
+        }
+        else{
+            this.addType =true
+            this.$$('#enable_scoring_coefficient').checked =false;
+            this.$$('#fieldRankingMultiplierInput').style.visibility ='hidden';
+        }
+    }
+
+    },
+    checkEditType: function()
+    {
+        if( this.$$('#editTypeValue').selectedItem !=undefined || this.$$('#editTypeValue').selectedItem!=null)
+        {var type = this.$$('#editTypeValue').selectedItem.value;
+        if(type=='number')
+        {
+            this.editType =false
+
+        }
+        else{
+            this.editType =true
+             this.$$('#rankingm').style.visibility = 'hidden';
+            this.$$('#enableScoringCoefficientEdit').checked =false
+        }
+    }
     },
     addNewField: function(){
 
@@ -1119,14 +1156,13 @@ poly = Polymer({
             this.$$("#fieldOrderInput").value = "";
             this.$$("#free_text_search").checked = false;
             this.$$('#fieldRankingMultiplierInput').value="";
-            this.$$('#enable_scoring_coefficient').checked =false;
             
             /*document.getElementById("fieldRuleExtractorTarget").selected = "2";*/
 
         }
     }.bind(this);
 
-    if(esc){
+    if(!this.addType && esc){
         var data = JSON.stringify({
             "field_name": name,
             "field_object": {
@@ -1186,8 +1222,6 @@ poly = Polymer({
                 "group_order": groupOrder,
                 "field_order": fieldOrder,
                 "free_text_search": free_text_search,
-                "scoring_coefficient": rankingMultiplier,
-                "enable_scoring_coefficient": esc
                 /*"rule_extraction_target": ruleextractTarget*/
             }
         });

--- a/ws/ws.py
+++ b/ws/ws.py
@@ -720,14 +720,12 @@ class ProjectFields(Resource):
         if 'free_text_search' not in field_obj \
                 or not isinstance(field_obj['free_text_search'], bool):
                 field_obj['free_text_search'] = False
-        if 'enable_scoring_coefficient' not in field_obj:
-                field_obj['enable_scoring_coefficient'] = False
+        if field_obj['type']!='number' and ('enable_scoring_coefficient' in field_obj or 'scoring_coefficient' in field_obj):
+                return False, 'Invalid field attributes: scoring_coefficient, enable_scoring_coefficient'
         if 'enable_scoring_coefficient' in field_obj and not isinstance(field_obj['enable_scoring_coefficient'],bool):
                 return False, 'Invalid field attribute: enable_scoring_coefficient'
         if 'scoring_coefficient' in field_obj and not (isinstance(field_obj['scoring_coefficient'],float) or isinstance(field_obj['scoring_coefficient'],int)):
                 return False, 'Invalid field attribute: scoring_coefficient'
-        # if 'scoring_coefficient' not isinstance(field_obj['scoring_coefficient'], float):
-        #         return False, 'Invalid field attribute: scoring_coefficient'
         return True, None
 
 
@@ -2291,6 +2289,7 @@ class Actions(Resource):
             es = ES(config['es']['sample_url'])
             r = es.search(project_name, data[project_name]['master_config']['root_name'],
                           query, ignore_no_index=True, filter_path=['aggregations'])
+
 
             if r is not None:
                 for obj in r['aggregations']['group_by_tld']['buckets']:

--- a/ws/ws.py
+++ b/ws/ws.py
@@ -720,8 +720,6 @@ class ProjectFields(Resource):
         if 'free_text_search' not in field_obj \
                 or not isinstance(field_obj['free_text_search'], bool):
                 field_obj['free_text_search'] = False
-        if 'scoring_coefficient' not in field_obj:
-                field_obj['scoring_coefficient'] = float(1.0)
         if 'enable_scoring_coefficient' not in field_obj:
                 field_obj['enable_scoring_coefficient'] = False
         if 'enable_scoring_coefficient' in field_obj and not isinstance(field_obj['enable_scoring_coefficient'],bool):


### PR DESCRIPTION
-  changed name of checkbox from 'Ranked Search' to 'Use in Document Search'
- 'Use in Document Search' checkbox remains disabled until the field type is number
- enable_ranking_coefficient and scoring_coefficient are in payload only when '
  Use in Document Search' is enable by user.
- validations for above added to back end.